### PR TITLE
Add first set of kotlin DL cases

### DIFF
--- a/accessing-android-external-storage/accessing-android-external-storage-compliant.kt
+++ b/accessing-android-external-storage/accessing-android-external-storage-compliant.kt
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-accessing-android-external-storage@v1.0 defects=0}
+import com.gurudetector.helper.ContextOther
+
+// Compliant: `context.getExternalFilesDir` is not from Context object.
+fun accessing_android_external_storage_compliant(context : ContextOther) {
+   context.getExternalFilesDir("filepath")
+}
+// {/fact}

--- a/accessing-android-external-storage/accessing-android-external-storage-non-compliant.kt
+++ b/accessing-android-external-storage/accessing-android-external-storage-non-compliant.kt
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-accessing-android-external-storage@v1.0 defects=1}
+import android.content.Context
+import java.io.File
+
+// Noncompliant: `context.getExternalFilesDir` returns absolute path to the directory on the primary shared/external storage device.
+fun accessing_android_external_storage_noncompliant(context : Context) {
+   val file = File(context.getExternalFilesDir("external"), "sensitive_data.txt")
+   file.writeText("This is sensitive information")
+}
+// {/fact}

--- a/anonymous-ldap-bind/anonymous-ldap-bind-compliant.kt
+++ b/anonymous-ldap-bind/anonymous-ldap-bind-compliant.kt
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-anonymous-ldap-bind@v1.0 defects=0}
+import javax.naming.directory.InitialDirContext
+import java.util.Hashtable
+import javax.naming.Context
+import javax.naming.directory.DirContext
+
+// Compliant: Enforcing authentication for LDAP statements.
+fun anonymous_ldap_bind_compliant(env: Hashtable<String, Any>) {
+    env.put(Context.SECURITY_AUTHENTICATION, "simple")
+    val ctx: DirContext = InitialDirContext(env)
+
+}
+// {/fact}

--- a/anonymous-ldap-bind/anonymous-ldap-bind-non-compliant.kt
+++ b/anonymous-ldap-bind/anonymous-ldap-bind-non-compliant.kt
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-anonymous-ldap-bind@v1.0 defects=1}
+import javax.naming.directory.InitialDirContext
+import java.util.Hashtable
+import javax.naming.Context
+import javax.naming.directory.DirContext
+
+// Noncompliant: Permiting anonymous users to execute LDAP statements
+fun anonymous_ldap_bind_noncompliant(env: Hashtable<String, Any>) {
+    env.put(Context.SECURITY_AUTHENTICATION, "none")
+    val ctx: DirContext = InitialDirContext(env)
+}
+// {/fact}

--- a/bad-hexa-conversion/bad-hexa-conversion-compliant.kt
+++ b/bad-hexa-conversion/bad-hexa-conversion-compliant.kt
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-bad-hexa-conversion@v1.0 defects=0}
+import java.security.MessageDigest
+import java.nio.charset.StandardCharsets
+import kotlin.experimental.and
+
+// Compliant: Using `String.format(\"%02X\",...)` which does not creates weak hash.
+fun bad_hexa_conversion_compliant(password: String): String {
+    val md: MessageDigest = MessageDigest.getInstance("SHA-1")
+    val resultBytes: ByteArray = md.digest(password.toByteArray(StandardCharsets.UTF_8))
+
+    var stringBuilder: StringBuilder = StringBuilder()
+    for (b in resultBytes) {
+        stringBuilder.append(String.format("%02X", b))
+    }
+    return stringBuilder.toString()
+}
+// {/fact}


### PR DESCRIPTION
Add first set of kotlin DL cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added security-focused examples illustrating compliant and non-compliant patterns for:
    - Android external storage access
    - LDAP binding (enforced authentication vs anonymous)
    - Hexadecimal conversion of password hash outputs
  - These examples help developers identify safe vs unsafe implementations through side-by-side contrasts.

- Documentation
  - Expanded guidance with practical code examples to clarify correct usage and common pitfalls in the above areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->