### PR TITLE
add second set of kotlin DL cases

### DIFF
--- a/bad-hexa-conversion/bad-hexa-conversion-non-compliant.kt
+++ b/bad-hexa-conversion/bad-hexa-conversion-non-compliant.kt
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-bad-hexa-conversion@v1.0 defects=1}
+import java.security.MessageDigest
+import java.nio.charset.StandardCharsets
+import kotlin.experimental.and
+
+// Noncompliant: Using `Integer.toHexString()` which creates weak hash.
+fun bad_hexa_conversion_noncompliant(password: String): String {
+    val md: MessageDigest = MessageDigest.getInstance("SHA-1")
+    val resultBytes: ByteArray = md.digest(password.toByteArray(StandardCharsets.UTF_8))
+
+    var stringBuilder: StringBuilder = StringBuilder()
+    for (b in resultBytes) {
+        stringBuilder.append(Integer.toHexString(b.toInt() and 0xFF))
+    }
+    return stringBuilder.toString()
+}
+// {/fact}

--- a/clear-text-protocol/clear-text-protocol-compliant.kt
+++ b/clear-text-protocol/clear-text-protocol-compliant.kt
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-clear-text-protocol@v1.0 defects=0}
+import org.apache.commons.net.ftp.FTPSClient
+
+// Compliant: Using clear-text protocols such as `ftps` which is secure.
+fun clear_text_protocol_compliant() {
+    val ftpsClient = FTPSClient(true);
+}
+// {/fact}

--- a/clear-text-protocol/clear-text-protocol-non-compliant.kt
+++ b/clear-text-protocol/clear-text-protocol-non-compliant.kt
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-clear-text-protocol@v1.0 defects=1}
+import org.apache.commons.net.ftp.FTPClient
+
+// Noncompliant: Using clear-text protocols such as `ftp` which is insecure.
+fun clear_text_protocol_noncompliant() {
+    val ftpClient = FTPClient()
+}
+// {/fact}

--- a/command-injection/command-injection-compliant.kt
+++ b/command-injection/command-injection-compliant.kt
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-command-injection@v1.0 defects=0}
+// Compliant: Hardcoded value is being passed to `exec`.
+fun command_injection_compliant() {
+    val directory = "hardcoded_value"
+
+    val command = "ls -l " + directory
+    val process = Runtime.getRuntime().exec(command)
+}
+// {/fact}

--- a/command-injection/command-injection-non-compliant.kt
+++ b/command-injection/command-injection-non-compliant.kt
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-command-injection@v1.0 defects=1}
+// Noncompliant: User input is being passed to `exec`.
+fun command_injection_noncompliant() {
+    print("Enter your input:")
+    val input = readLine()
+
+    val command = "echo Hello, $input"
+    val process = Runtime.getRuntime().exec(String.format("The value is: %s", command))
+}
+// {/fact}


### PR DESCRIPTION
add second set of kotlin DL cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Kotlin examples highlighting secure vs. insecure command execution to illustrate command injection risks.
  - Introduced examples contrasting secure encrypted file transfer with insecure clear‑text protocols.
  - Included an example demonstrating pitfalls of improper hex encoding of cryptographic digests.

- Documentation
  - Expanded guidance on preventing command injection and avoiding clear‑text protocols.
  - Clarified best practices for correctly converting cryptographic digests to hexadecimal strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->