### PR TITLE
Add third set of kotlin DL cases

### DIFF
--- a/cookie-missing-httponly/cookie-missing-httponly-compliant.kt
+++ b/cookie-missing-httponly/cookie-missing-httponly-compliant.kt
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-cookie-missing-httponly@v1.0 defects=0}
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+
+// Compliant: The `HttpOnly` flag of cookies is set to `true`.
+fun cookie_missing_httponly_compliant(value: String, response: HttpServletResponse) {
+    val cookie: Cookie = Cookie("cookie", value)
+    cookie.setHttpOnly(true)
+    response.addCookie(cookie)
+}
+// {/fact}

--- a/cookie-missing-httponly/cookie-missing-httponly-non-compliant.kt
+++ b/cookie-missing-httponly/cookie-missing-httponly-non-compliant.kt
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-cookie-missing-httponly@v1.0 defects=1}
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+
+// Noncompliant: The `HttpOnly` flag of cookies is set to `false`.
+fun cookie_missing_httponly_noncompliant(value: String, response: HttpServletResponse) {
+    val cookie: Cookie = Cookie("cookie", value)
+    cookie.setHttpOnly(false)
+    response.addCookie(cookie)
+}
+// {/fact}

--- a/cookie-missing-secure-flag/cookie-missing-secure-flag-compliant.kt
+++ b/cookie-missing-secure-flag/cookie-missing-secure-flag-compliant.kt
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-cookie-missing-secure-flag@v1.0 defects=0}
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+import org.springframework.web.bind.annotation.RequestParam
+
+// Compliant: The `Secure` attribute of cookies is set to `true`.
+fun cookie_missing_secure_flag_compliant(@RequestParam value: String, response: HttpServletResponse) {
+    var cookie: Cookie = Cookie("cookie", value)
+    cookie.setSecure(true)
+    response.addCookie(cookie)
+}
+// {/fact}

--- a/cookie-missing-secure-flag/cookie-missing-secure-flag-non-compliant.kt
+++ b/cookie-missing-secure-flag/cookie-missing-secure-flag-non-compliant.kt
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-cookie-missing-secure-flag@v1.0 defects=1}
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+import org.springframework.web.bind.annotation.RequestParam
+
+// Noncompliant:  The `Secure` flag of cookies is set to `false`.
+fun cookie_missing_secure_flag_noncompliant(@RequestParam value: String, response: HttpServletResponse) {
+    var cookie: Cookie = Cookie("cookie", value)
+    cookie.setSecure(false)
+    cookie.setHttpOnly(false)
+    response.addCookie(cookie)
+}
+// {/fact}

--- a/cross-site-scripting/cross-site-scripting-compliant.kt
+++ b/cross-site-scripting/cross-site-scripting-compliant.kt
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// {fact rule=kotlin-cross-site-scripting@v1.0 defects=0}
+import java.io.PrintWriter
+
+// Compliant: Not using any unsanitized external inputs.
+fun cross_site_scripting_compliant() {
+    print("Enter your name:")
+    val name = readLine()
+
+    val writer = PrintWriter(System.out)
+    writer.write("<p>Hello, name!</p>")
+}
+// {/fact}


### PR DESCRIPTION
Add third set of kotlin DL cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added options to issue cookies with the HttpOnly attribute enabled.
  - Added options to issue cookies with the Secure attribute enabled.
  - Included demo variants with these flags disabled for comparison/testing scenarios.
  - Introduced an example that outputs static HTML content without using user input, illustrating safe rendering against cross-site scripting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->