### PR TITLE
Add 4th set if csharp DS samples

### DIFF
--- a/codeql_csharp/RuntimeChecksBypassGood.cs
+++ b/codeql_csharp/RuntimeChecksBypassGood.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Serialization;
+
+[Serializable]
+public class PersonGood : ISerializable
+{
+    public int Age;
+
+    public PersonGood(int age)
+    {
+        if (age < 0)
+            throw new ArgumentException(nameof(age));
+        Age = age;
+    }
+
+    [OnDeserializing]
+    //{fact rule=untrusted-deserialization@v1.0 defects=0}
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        int age = info.GetInt32("age");
+        if (age < 0)
+            throw new SerializationException(nameof(Age));
+        Age = age;  // GOOD - write is safe
+    }
+    //{/fact}
+}

--- a/codeql_csharp/UncontrolledFormatStringBad.cs
+++ b/codeql_csharp/UncontrolledFormatStringBad.cs
@@ -1,0 +1,16 @@
+using System.Web;
+
+public class HttpHandler : IHttpHandler
+{
+    string Surname, Forenames, FormattedName;
+
+    public void ProcessRequest(HttpContext ctx)
+    {
+        string format = (string)ctx.Request;
+
+        //{fact rule=untrusted-format-strings@v1.0 defects=1}
+        // BAD: Uncontrolled format string.
+        FormattedName = string.Format(format, Surname, Forenames);
+        //{/fact}
+    }
+}

--- a/codeql_csharp/UnsafeDeserializationBad.cs
+++ b/codeql_csharp/UnsafeDeserializationBad.cs
@@ -1,0 +1,37 @@
+class UnsafeDeserializationBad
+{
+    public static object Deserialize(string s)
+    {
+        JavaScriptSerializer sr = new(new SimpleTypeResolver());
+        //{fact rule=untrusted-deserialization@v1.0 defects=1}
+        // BAD
+        return sr.DeserializeObject(s);
+        //{/fact}
+    }
+}
+
+internal class SimpleTypeResolver
+{
+    public SimpleTypeResolver()
+    {
+    }
+}
+
+internal class JavaScriptSerializer
+{
+    private SimpleTypeResolver simpleTypeResolver;
+
+    public JavaScriptSerializer()
+    {
+    }
+
+    public JavaScriptSerializer(SimpleTypeResolver simpleTypeResolver)
+    {
+        this.simpleTypeResolver = simpleTypeResolver;
+    }
+
+    internal object DeserializeObject(string s)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/codeql_csharp/UnsafeDeserializationGood.cs
+++ b/codeql_csharp/UnsafeDeserializationGood.cs
@@ -1,0 +1,11 @@
+class Good
+{
+    public static object Deserialize(string s)
+    {
+        //{fact rule=untrusted-deserialization@v1.0 defects=0}
+        // GOOD
+        JavaScriptSerializer sr = new();
+        return sr.DeserializeObject(s);
+        //{/fact}
+    }
+}

--- a/codeql_csharp/UnsafeDeserializationUntrustedInputTypeBad.cs
+++ b/codeql_csharp/UnsafeDeserializationUntrustedInputTypeBad.cs
@@ -1,0 +1,15 @@
+using System.Runtime.Serialization.Json;
+using System.IO;
+using System;
+
+class BadDataContractJsonSerializer
+{
+    public static object Deserialize(string type, Stream s)
+    {
+        //{fact rule=object-input-stream-insecure-deserialization@v1.0 defects=1}
+        // BAD: stream and type are potentially untrusted
+        var ds = new DataContractJsonSerializer(Type.GetType(type));
+        return ds.ReadObject(s);
+        //{/fact}
+    }
+}


### PR DESCRIPTION
Add 4th set if csharp DS samples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added C# examples illustrating safe handling of runtime checks and serialization validation.
  - Introduced demonstrations of unsafe deserialization scenarios, including untrusted input and type-based deserialization risks.
  - Added a counterpart example showing safer deserialization practices.
  - Included a sample highlighting uncontrolled format string risks in request handling.
  - These additions expand the security-focused sample suite for learning and testing static analysis or scanning tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->