### PR TITLE
Add Csharp Files from csharp_semgrep_rules - Batch 01

### DIFF
--- a/insecure-typefilterlevel-full.cs
+++ b/insecure-typefilterlevel-full.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Runtime.Serialization.Formatters;
+
+namespace InsecureDeserialization
+{
+    public class InsecureTypeFilterLevel
+    {
+        private object formatterProps;
+
+        public void SetTFL(string json)
+        {
+            BinaryServerFormatterSinkProvider serverProvider = new BinaryServerFormatterSinkProvider(formatterProps, null);
+
+            //{fact rule=untrusted-deserialization@v1.0 defects=1}
+            // ruleid: insecure-typefilterlevel-full
+            serverProvider.TypeFilterLevel = System.Runtime.Serialization.Formatters.TypeFilterLevel.Full;
+
+            //{/fact}
+
+            //{fact rule=untrusted-deserialization@v1.0 defects=1}
+            // ruleid: insecure-typefilterlevel-full
+            var provider = new BinaryServerFormatterSinkProvider(formatterProps, null);
+			//{ "TypeFilterLevel" = TypeFilterLevel.Full };
+
+            var dict = new Hashtable();
+            dict["typeFilterLevel"] = "Full";
+            //{/fact}
+
+            //{fact rule=untrusted-deserialization@v1.0 defects=1}
+            // ruleid: insecure-typefilterlevel-full
+            BinaryServerFormatterSinkProvider serverProvider2 = new BinaryServerFormatterSinkProvider(dict, null);
+        }
+    }
+
+    internal class BinaryServerFormatterSinkProvider
+    {
+        private object formatterProps;
+        private object value;
+
+        public BinaryServerFormatterSinkProvider(object formatterProps, object value)
+        {
+            this.formatterProps = formatterProps;
+            this.value = value;
+        }
+
+        public TypeFilterLevel TypeFilterLevel { get; internal set; }
+    }
+}
+            //{/fact}

--- a/os-command.cs
+++ b/os-command.cs
@@ -1,0 +1,149 @@
+using System.Diagnostics;
+
+namespace Injections
+{
+    public class OsCommandInjection
+    {
+        public void RunOsCommand(string command)
+        {
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            var process = Process.Start(command);
+        }
+        //{/fact}
+
+        public void RunOsCommand2(string command)
+        {
+
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            var process = Process.Start("constant");
+            //{/fact}
+        }
+
+
+        public void RunOsCommandWithArgs(string command, string arguments)
+        {
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            var process = Process.Start(command, arguments);
+            //{/fact}
+        }
+
+        public void RunOsCommandWithArgs2(string command, string arguments)
+        {
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            var process = Process.Start("constant", "constant");
+            //{/fact}
+        }
+
+
+        public void RunOsCommandWithProcessParam(string command)
+        {
+            Process process = new Process();
+
+            process.StartInfo.FileName = command;
+
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            process.Start();
+            //{/fact}
+        }
+
+        public void RunOsCommandWithProcessParam2(string command)
+        {
+            Process process = new Process();
+
+            process.StartInfo.FileName = "constant";
+
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            process.Start();
+            //{/fact}
+        }
+
+
+        public void RunOsCommandAndArgsWithProcessParam(string command, string arguments)
+        {
+            Process process = new Process();
+
+            process.StartInfo.FileName = command;
+            process.StartInfo.Arguments = arguments;
+
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            process.Start();
+            //{/fact}
+        }
+
+        public void RunOsCommandAndArgsWithProcessParam2(string command, string arguments)
+        {
+            Process process = new Process();
+
+            process.StartInfo.FileName = "constant";
+            process.StartInfo.Arguments = "constant";
+
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            process.Start();
+            //{/fact}
+        }
+
+
+        public void RunOsCommandWithStartInfo(string command)
+        {
+            ProcessStartInfo processStartInfo = new ProcessStartInfo()
+            {
+                FileName = command
+            };
+
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            var process = Process.Start(processStartInfo);
+            //{/fact}
+        }
+
+        public void RunOsCommandWithStartInfo2(string command)
+        {
+            ProcessStartInfo processStartInfo = new ProcessStartInfo()
+            {
+                FileName = "constant"
+            };
+
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            var process = Process.Start(processStartInfo);
+            //{/fact}
+        }
+
+
+        public void RunConstantAppWithArgs(string args)
+        {
+            ProcessStartInfo processStartInfo = new ProcessStartInfo()
+            {
+                FileName = "constant",
+                Arguments = args
+            };
+
+            //{fact rule=os-command-injection@v1.0 defects=1}
+            // ruleid: os-command-injection
+            var process = Process.Start(processStartInfo);
+            //{/fact}
+        }
+
+        public void RunConstantAppWithArgs2(string args)
+        {
+            ProcessStartInfo processStartInfo = new ProcessStartInfo()
+            {
+                FileName = "constant",
+                Arguments = "constant"
+            };
+
+            //{fact rule=os-command-injection@v1.0 defects=0}
+            // ok: os-command-injection
+            var process = Process.Start(processStartInfo);
+        }
+    }
+}
+            //{/fact}

--- a/razor-template-injection.cs
+++ b/razor-template-injection.cs
@@ -1,0 +1,79 @@
+namespace RazorVulnerableApp.Controllers
+{
+    public class HomeController : Controller
+    {
+        [HttpPost]
+        [ValidateInput(false)]
+        public ActionResult Index(string inert, string razorTpl)
+        {
+            // WARNING This code is vulnerable on purpose: do not use in production and do not take it as an example!
+            //{fact rule=code-injection@v1.0 defects=1}
+            // ruleid: razor-template-injection
+            ViewBag.RenderedTemplate = Razor.Parse(razorTpl);
+            ViewBag.Template = razorTpl;
+            return View();
+        }
+
+        private ActionResult View()
+        {
+            throw new NotImplementedException();
+        }
+
+        //{/fact}
+
+        [HttpPost]
+        [ValidateInput(false)]
+        public ActionResult Index2(string inter, string razorTpl)
+        {
+            var junk = someFunction(razorTpl);
+            // WARNING This code is vulnerable on purpose: do not use in production and do not take it as an example!
+
+            //{fact rule=code-injection@v1.0 defects=0}
+            // ok: razor-template-injection
+            ViewBag.RenderedTemplate = Razor.Parse(junk);
+            ViewBag.Template = razorTpl;
+            return View();
+        }
+
+        private string someFunction(string razorTpl)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class Razor
+    {
+        internal static object Parse(string razorTpl)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class ViewBag
+    {
+        public static object? RenderedTemplate { get; internal set; }
+        public static string? Template { get; internal set; }
+    }
+
+    public class ActionResult
+    {
+    }
+
+    internal class ValidateInputAttribute : Attribute
+    {
+        private bool v;
+
+        public ValidateInputAttribute(bool v)
+        {
+            this.v = v;
+        }
+    }
+
+    internal class HttpPostAttribute : Attribute
+    {
+    }
+
+    public class Controller
+    {
+    }
+}            //{/fact}

--- a/use_ecb_mode.cs
+++ b/use_ecb_mode.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Security.Cryptography;
+					
+public class Encryption_new
+{
+	public void EncryptWithAesEcb() {
+		Aes key = Aes.Create();
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var encryptor = key.CreateEncryptor();
+		byte[] msg = new byte[32];
+		var cipherText = encryptor.TransformFinalBlock(msg, 0, msg.Length);
+	}
+	//{/fact}
+	
+	public void EncryptWithAesEcb2() {
+		Aes key = Aes.Create();
+		byte[] msg = new byte[32];
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var cipherText = key.EncryptEcb(msg, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void DecryptWithAesEcb(byte[] cipherText) {
+		Aes key = Aes.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var decryptor = key.CreateDecryptor();
+		var msg = decryptor.TransformFinalBlock(cipherText, 0, cipherText.Length);
+	}
+	//{/fact}
+	public void DecryptWithAesEcb2(byte[] cipherText) {
+		Aes key = Aes.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var msgText = key.DecryptEcb(cipherText, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void EncryptWith3DESEcb() {
+		TripleDES key = TripleDES.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var encryptor = key.CreateEncryptor();
+		byte[] msg = new byte[32];
+		var cipherText = encryptor.TransformFinalBlock(msg, 0, msg.Length);
+	}
+	//{/fact}
+	
+	public void EncryptWith3DESEcb2() {
+		TripleDES key = TripleDES.Create();
+		byte[] msg = new byte[32];
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var cipherText = key.EncryptEcb(msg, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void DecryptWith3DESEcb(byte[] cipherText) {
+		TripleDES key = TripleDES.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var decryptor = key.CreateDecryptor();
+		var msg = decryptor.TransformFinalBlock(cipherText, 0, cipherText.Length);
+	}
+	//{/fact}
+	
+	public void DecryptWith3DESEcb2(byte[] cipherText) {
+		TripleDES key = TripleDES.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var msgText = key.DecryptEcb(cipherText, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void EncryptWithEcb(SymmetricAlgorithm key) {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var encryptor = key.CreateEncryptor();
+		byte[] msg = new byte[32];
+		var cipherText = encryptor.TransformFinalBlock(msg, 0, msg.Length);
+	}
+	//{/fact}
+	
+	public void EncryptWithEcb2(SymmetricAlgorithm key) {
+		byte[] msg = new byte[32];
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var cipherText = key.EncryptEcb(msg, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void DecryptWithEcb(SymmetricAlgorithm key, byte[] cipherText) {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		key.Mode = CipherMode.ECB; // DevSkim: ignore DS187371
+		using var decryptor = key.CreateDecryptor();
+		var msg = decryptor.TransformFinalBlock(cipherText, 0, cipherText.Length);
+	}
+	//{/fact}
+	
+	public void DecryptWithEcb2(SymmetricAlgorithm key, byte[] cipherText) {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_ecb_mode
+		var msgText = key.DecryptEcb(cipherText, PaddingMode.PKCS7);
+	}
+	//{/fact}
+	
+	public void EncryptWithAesCbc() {
+		Aes key = Aes.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_ecb_mode
+		key.Mode = CipherMode.CBC;
+		using var encryptor = key.CreateEncryptor();
+		byte[] msg = new byte[32];
+		var cipherText = encryptor.TransformFinalBlock(msg, 0, msg.Length);
+	}
+	//{/fact}
+	
+	public void EncryptWithAesCbc2() {
+		Aes key = Aes.Create();
+		byte[] msg = new byte[32];
+		byte[] iv = new byte[16];
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_ecb_mode
+		var cipherText = key.EncryptCbc(msg, iv, PaddingMode.PKCS7);
+	}
+		//{/fact}
+	
+	public void DecryptWithAesCbc(byte[] cipherText) {
+		Aes key = Aes.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_ecb_mode		
+		key.Mode = CipherMode.CBC;
+		using var decryptor = key.CreateDecryptor();
+		var msg = decryptor.TransformFinalBlock(cipherText, 0, cipherText.Length);
+	}
+	//{/fact}
+	
+	public void DecryptWithAesCbc2(byte[] cipherText, byte[] iv) {
+		Aes key = Aes.Create();
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_ecb_mode		
+		var msgText = key.DecryptCbc(cipherText, iv, PaddingMode.PKCS7);
+	}	
+
+	//{/fact}
+	public static void Main1()
+	{
+		Console.WriteLine("Hello World");
+	}
+}

--- a/use_weak_rsa_encryption_padding.cs
+++ b/use_weak_rsa_encryption_padding.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Security.Cryptography;
+					
+public class RSAEncryption
+{
+	public static void EncryptWithBadPadding1()
+	{
+		RSA key = RSA.Create();
+		byte[] msg = new byte[16];
+		Type t = typeof(byte[]);
+		RSAPKCS1KeyExchangeFormatter formatter = new RSAPKCS1KeyExchangeFormatter(key);
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_weak_rsa_encryption_padding
+		byte[] cipherText = formatter.CreateKeyExchange(msg, t);
+	}
+	//{/fact}
+	
+	public static void DecryptWithBadPadding()
+	{
+		RSA key = RSA.Create();
+		byte[] ciphertext = new byte[16];
+		var deformatter = new RSAPKCS1KeyExchangeDeformatter(key);
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_weak_rsa_encryption_padding
+		var plaintext = deformatter.DecryptKeyExchange(ciphertext);
+	}
+	//{/fact}
+
+	public static void EncryptWithBadPadding2()
+	{
+		RSA key = RSA.Create();
+		byte[] msg = new byte[16];
+		var formatter = new RSAPKCS1KeyExchangeFormatter(key);
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_weak_rsa_encryption_padding
+		byte[] cipherText = formatter.CreateKeyExchange(msg);
+	}
+	//{/fact}
+
+	public static void EncryptWithGoodPadding1()
+	{
+		RSA key = RSA.Create();
+		byte[] msg = new byte[16];
+		Type t = typeof(byte[]);
+		AsymmetricKeyExchangeFormatter formatter = new RSAOAEPKeyExchangeFormatter(key);
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_weak_rsa_encryption_padding
+		byte[] cipherText = formatter.CreateKeyExchange(msg, t);
+	}
+	//{/fact}
+	
+	public static void EncryptWithGoodPadding2()
+	{
+		RSA key = RSA.Create();
+		byte[] msg = new byte[16];
+		AsymmetricKeyExchangeFormatter formatter = new RSAOAEPKeyExchangeFormatter(key);
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_weak_rsa_encryption_padding
+		byte[] cipherText = formatter.CreateKeyExchange(msg);
+	}
+	//{/fact}
+
+	public static void DecryptWithGoodPadding()
+	{
+		RSA key = RSA.Create();
+		byte[] ciphertext = new byte[16];
+		var deformatter = new RSAOAEPKeyExchangeDeformatter(key);
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_weak_rsa_encryption_padding
+		var plaintext = deformatter.DecryptKeyExchange(ciphertext);
+	}
+	//{/fact}
+
+	
+	public static void Main1(string[] args){
+	}
+}
+


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Csharp files from the `csharp_semgrep_rules` directory to the repository.

## 📁 Files Added
- Source Folder: `csharp_semgrep_rules`
- Batch: csharp-semgrep-rules-csharp-batch-01
- Language: Csharp
- Contains csharp files collected from the source directory

## 🔍 Changes
- Added csharp files from `csharp_semgrep_rules` maintaining original directory structure
- Files organized in batch 01 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `csharp_semgrep_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added modules demonstrating command execution flows (with/without arguments and start info).
  - Introduced controller endpoints that process input-based template strings.
  - Included components showing deserialization configuration behavior.
  - Added cryptography examples for AES/3DES using ECB and CBC modes.
  - Provided RSA key exchange examples featuring multiple padding schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->