### PR TITLE
Add Csharp Files from csharp_semgrep_rules - Batch 02

### DIFF
--- a/http-listener-wildcard-bindings.cs
+++ b/http-listener-wildcard-bindings.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net;
+
+namespace HttpListenerWildcard {
+    class MyBadHttpListener {
+        public static void HttpListenerWildcard() {
+            HttpListener listener = new HttpListener();
+
+            //{fact rule=module-injection@v1.0 defects=1}
+            // ruleid: http-listener-wildcard-bindings
+            listener.Prefixes.Add("https://*:8080");
+
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=1}
+            // ruleid: http-listener-wildcard-bindings
+            listener.Prefixes.Add("http://+:8080");
+
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=1}
+            // ruleid: http-listener-wildcard-bindings
+            listener.Prefixes.Add("https://*:8080");
+
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=1}
+            // ruleid: http-listener-wildcard-bindings
+            listener.Prefixes.Add("https://+:8080");
+
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=1}
+            // ruleid: http-listener-wildcard-bindings
+            listener.Prefixes.Add("https://*.com:8080");
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=0}
+            // ok
+            listener.Prefixes.Add("https://0.0.0.0:8080");
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=0}
+            // ok
+            listener.Prefixes.Add("http://www.contoso.com:8080/");
+            //{/fact}
+
+            //{fact rule=module-injection@v1.0 defects=0}
+            // ok
+            listener.Prefixes.Add("http://*.test.com:8080");
+
+            listener.Start();
+              //{/fact}
+        }
+    }
+}

--- a/los-formatter.cs
+++ b/los-formatter.cs
@@ -1,0 +1,29 @@
+namespace InsecureDeserialization
+{
+    public class InsecureLosFormatterDeserialization
+    {
+        public void LosFormatterDeserialization(string json)
+        {
+            try
+            {
+                //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                // ruleid: insecure-losformatter-deserialization
+                LosFormatter losFormatter = new LosFormatter();
+                object obj = losFormatter.Deserialize(json);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    internal class LosFormatter
+    {
+        internal object Deserialize(string json)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+                //{/fact}

--- a/regular-expression-dos-infinite-timeout.cs
+++ b/regular-expression-dos-infinite-timeout.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+using System;
+namespace RegularExpressionsDosInfiniteTimeout
+{
+    
+    public class RegularExpressionsDosInfiniteTimeout
+    {
+        private static string pattern;
+
+        // ok
+        Regex rgx = new Regex(pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
+        
+        //{fact rule=regular-expression-dos-infinite-timeout@v1.0 defects=1}
+        // ruleid: regular-expression-dos-infinite-timeout
+        Regex rgx0 = new Regex(pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(10));
+        
+        //{/fact}
+
+        //{fact rule=regular-expression-dos-infinite-timeout@v1.0 defects=1}
+        // ruleid: regular-expression-dos-infinite-timeout
+        Regex rgx1 = new Regex(pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(10));
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos-infinite-timeout@v1.0 defects=1}
+        // ruleid: regular-expression-dos-infinite-timeout
+        Regex rgx2 = new Regex(pattern, RegexOptions.IgnoreCase, TimeSpan.FromMinutes(1));
+        
+        //{/fact}
+
+        //{fact rule=regular-expression-dos-infinite-timeout@v1.0 defects=1}
+        // ruleid: regular-expression-dos-infinite-timeout
+        Regex rgx3 = new Regex(pattern, RegexOptions.IgnoreCase, TimeSpan.FromHours(1));
+    }
+}
+        //{/fact}

--- a/sslcertificatetrust-handshake-no-trust.fixed.cs
+++ b/sslcertificatetrust-handshake-no-trust.fixed.cs
@@ -1,0 +1,57 @@
+using System.Net.Security;
+
+public class Fo
+{
+    private void SomeFunction(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,false);
+    }
+    //{/fact}
+
+    private void SomeFunction2(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,false);
+    }
+    //{/fact}
+
+    private void SomeFunction3(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ok: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection);
+    }
+    //{/fact}
+
+    private void SomeFunction4(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,false);
+    }
+    //{/fact}
+
+    private void SomeFunction5(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,false);
+    }
+    //{/fact}
+
+    private void SomeFunction6(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ok: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection);
+    }
+}
+        //{/fact}

--- a/xmldocument-unsafe-parser-override.cs
+++ b/xmldocument-unsafe-parser-override.cs
@@ -1,0 +1,44 @@
+using System.Xml;
+
+public class Foonew{
+    public void LoadBad(string input)
+    {
+        // string fileName = @"C:\Users\user\Documents\test.xml";
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.XmlResolver = new XmlUrlResolver();
+        //{fact rule=xml-external-entity@v1.0 defects=1}
+        // ruleid: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
+
+        Console.ReadLine();
+    }
+    //{/fact}
+
+    public static void StaticLoadBad(string input)
+    {
+        // string fileName = @"C:\Users\user\Documents\test.xml";
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.XmlResolver = new XmlUrlResolver();
+
+        //{fact rule=xml-external-entity@v1.0 defects=1}
+        // ruleid: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
+
+        Console.ReadLine();
+    }
+    //{/fact}
+    
+    public void LoadGood(string input)
+    {
+        XmlDocument xmlDoc = new XmlDocument();
+
+        //{fact rule=xml-external-entity@v1.0 defects=0}
+        // ok: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
+
+        Console.ReadLine();
+    }
+}        //{/fact}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Csharp files from the `csharp_semgrep_rules` directory to the repository.

## 📁 Files Added
- Source Folder: `csharp_semgrep_rules`
- Batch: csharp-semgrep-rules-csharp-batch-02
- Language: Csharp
- Contains csharp files collected from the source directory

## 🔍 Changes
- Added csharp files from `csharp_semgrep_rules` maintaining original directory structure
- Files organized in batch 02 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `csharp_semgrep_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added examples demonstrating HTTP listener wildcard binding scenarios.
  - Introduced a sample showcasing deserialization behavior with error handling.
  - Provided configurable regular expression timeout examples to illustrate performance safeguards.
  - Added utilities demonstrating SSL certificate trust configuration scenarios.
  - Introduced XML loading examples contrasting safe and unsafe resolver usage.

- Chores
  - Added new sample files to expand the security-focused example suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->