### PR TITLE
Add Csharp Files from csharp_semgrep_rules - Batch 03

### DIFF
--- a/data-contract-resolver.cs
+++ b/data-contract-resolver.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace DCR
+{
+    //{fact rule=untrusted-deserialization@v1.0 defects=1}
+    // ruleid: data-contract-resolver
+    class MyDCR : DataContractResolver
+    {
+        public void ResolveDataContract()
+        {
+            
+        }
+
+        public override Type? ResolveName(string typeName, string? typeNamespace, Type? declaredType, DataContractResolver knownTypeResolver)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool TryResolveType(Type type, Type? declaredType, DataContractResolver knownTypeResolver, out XmlDictionaryString? typeName, out XmlDictionaryString? typeNamespace)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+    //{/fact}

--- a/http-client.cs
+++ b/http-client.cs
@@ -1,0 +1,263 @@
+using System.Net.Http;
+using System;
+namespace ServerSideRequestForgery
+{
+    public class Ssrf
+    {
+        #region Pattern 1
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientAsync(string host)
+        {
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(host).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientAsync2(string host)
+        {
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(host + "constant").Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientAsync1(string host)
+        {
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync("constant").Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+
+        #region Pattern 2
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientAsyncWithStringConcatenation(string host)
+        {
+            string uri = host + "constant";
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientAsyncWithStringConcatenation1(string host)
+        {
+            string uri = "constant";
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientAsyncWithUri(string host)
+        {
+            Uri uri = new Uri(host);
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientAsyncWithUri1(string host)
+        {
+            Uri uri = new Uri("constant");
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+
+        #region Pattern 3
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientStringAsync(string host)
+        {
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(host).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientStringAsync1(string host)
+        {
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync("constant").Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+
+        #region Pattern 4
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientStringAsyncWithStringConcatenation(string host)
+        {
+            string uri = host + "constant";
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientStringAsyncWithStringConcatenation1(string host)
+        {
+            string uri = "constant";
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void HttpClientStringAsyncWithUri(string host)
+        {
+            Uri uri = new Uri(host);
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void HttpClientStringAsyncWithUri1(string host)
+        {
+            Uri uri = new Uri("constant");
+
+            HttpClient client = new HttpClient();
+
+            try
+            {
+                HttpResponseMessage response = client.GetAsync(uri).Result;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+    }
+}
+        //{/fact}

--- a/newtonsoft.cs
+++ b/newtonsoft.cs
@@ -1,0 +1,119 @@
+using Newtonsoft.Json;
+
+namespace InsecureDeserialization
+{
+    public class InsecureNewtonsoftDeserialization
+    {
+        private object someJson;
+        private object traceWriter;
+
+        public object InvariantCulture { get; private set; }
+
+        public void NewtonsoftDeserialization(string json)
+        {
+            try
+            {
+                JsonConvert.DeserializeObject<object>(json, new JsonSerializerSettings
+                {
+                    //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                    // ruleid: insecure-newtonsoft-deserialization
+                    TypeNameHandling = TypeNameHandling.All
+                });
+            } catch(Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }//{/fact}
+
+        public void ConverterOverrideSettings(){
+            JsonConvert.DefaultSettings = () => 
+
+                //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                //ruleid: insecure-newtonsoft-deserialization
+                new JsonSerializerSettings{TypeNameHandling = TypeNameHandling.Auto};
+            Bar newBar = JsonConvert.DeserializeObject<Bar>(someJson);
+        }
+        //{/fact}
+
+        public void ConverterOverrideSettingsStaggeredInitialize(){
+            var settings = new JsonSerializerSettings();
+
+            //{fact rule=untrusted-deserialization@v1.0 defects=1}
+            //ruleid: insecure-newtonsoft-deserialization
+            settings.TypeNameHandling = TypeNameHandling.Auto;
+            Bar newBar = JsonConvert.DeserializeObject<Bar>(someJson,settings);
+        }
+        //{/fact}
+
+        public void ConverterOverrideSettingsMultipleSettingArgs(){
+            JsonConvert.DefaultSettings = () => 
+                new JsonSerializerSettings{
+                    Culture = InvariantCulture,
+
+                    //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                    //ruleid: insecure-newtonsoft-deserialization
+                    TypeNameHandling = TypeNameHandling.Auto,
+                    TraceWriter = traceWriter
+                    };
+            Bar newBar = JsonConvert.DeserializeObject<Bar>(someJson);
+        }
+        //{/fact}
+
+      public void SafeDeserialize(){
+        Bar newBar = JsonConvert.DeserializeObject<Bar>(someJson, new JsonSerializerSettings
+        {
+
+            //{fact rule=untrusted-deserialization@v1.0 defects=0}
+            //ok: insecure-newtonsoft-deserialization
+            TypeNameHandling = TypeNameHandling.None
+        });
+      }
+      //{/fact}
+
+      public void SafeDefaults(){
+
+        //{fact rule=untrusted-deserialization@v1.0 defects=0}
+        //ok: insecure-newtonsoft-deserialization
+        Bar newBar = JsonConvert.DeserializeObject<Bar>(someJson);
+      }
+    }
+
+    internal class Bar
+    {
+    }
+
+    internal class TypeNameHandling
+    {
+        public static object All { get; internal set; }
+        public static object Auto { get; internal set; }
+        public static object None { get; internal set; }
+    }
+
+    internal class JsonSerializerSettings
+    {
+        public object TypeNameHandling { get; set; }
+        public object Culture { get; internal set; }
+        public object TraceWriter { get; internal set; }
+    }
+
+    internal class JsonConvert
+    {
+        public static Func<JsonSerializerSettings> DefaultSettings { get; internal set; }
+
+        internal static void DeserializeObject<T>(string json, JsonSerializerSettings jsonSerializerSettings)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static T DeserializeObject<T>(object someJson, JsonSerializerSettings settings)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static T DeserializeObject<T>(object someJson)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+        //{/fact}

--- a/soap-formatter.cs
+++ b/soap-formatter.cs
@@ -1,0 +1,33 @@
+using System.Text;
+
+namespace InsecureDeserialization
+{
+    public class InsecureSoapFormatterDeserialization
+    {
+        public void SoapFormatterDeserialization(string json)
+        {
+            try
+            {
+                MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+                //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                // ruleid: insecure-soapformatter-deserialization
+                SoapFormatter soapFormatter = new SoapFormatter();
+                object obj = soapFormatter.Deserialize(ms);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    internal class SoapFormatter
+    {
+        internal object Deserialize(MemoryStream ms)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+                //{/fact}

--- a/xmltextreader-unsafe-defaults.cs
+++ b/xmltextreader-unsafe-defaults.cs
@@ -1,0 +1,96 @@
+using System.Xml;
+
+namespace SomeNamespace
+{
+    public class Foo{
+        public void ReaderBad(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+						myReader.XmlResolver = new XmlUrlResolver();
+						
+            //{fact rule=xml-external-entity@v1.0 defects=1}
+            // ruleid: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    //{/fact}
+                    //{fact rule=xml-external-entity@v1.0 defects=1}
+                    // ruleid: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+            }
+            Console.ReadLine();
+        }
+        //{/fact}
+
+        public static void StaticReaderBad(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+						myReader.XmlResolver = new XmlUrlResolver();
+
+            //{fact rule=xml-external-entity@v1.0 defects=1}
+            // ruleid: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    //{/fact}
+                    //{fact rule=xml-external-entity@v1.0 defects=1}
+                    // ruleid: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+            }
+            Console.ReadLine();
+        }
+        //{/fact}
+
+        public void ReaderGood(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+            myReader.DtdProcessing = DtdProcessing.Prohibit;
+
+            //{fact rule=xml-external-entity@v1.0 defects=0}
+            // ok: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    //{/fact}
+                    
+                    //{fact rule=xml-external-entity@v1.0 defects=0}
+                    // ok: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+                //{/fact}
+            }
+            Console.ReadLine();
+        }
+    }
+
+    internal class XmlNodeType
+    {
+        public static object Element { get; internal set; }
+    }
+
+    internal class XmlTextReader
+    {
+        public XmlTextReader(StringReader stringReader)
+        {
+        }
+
+        public object NodeType { get; internal set; }
+        public object DtdProcessing { get; internal set; }
+
+        internal bool Read()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal bool ReadElementContentAsString()
+        {
+            throw new NotImplementedException();
+        }
+    }
+ 
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Csharp files from the `csharp_semgrep_rules` directory to the repository.

## 📁 Files Added
- Source Folder: `csharp_semgrep_rules`
- Batch: csharp-semgrep-rules-csharp-batch-03
- Language: Csharp
- Contains csharp files collected from the source directory

## 🔍 Changes
- Added csharp files from `csharp_semgrep_rules` maintaining original directory structure
- Files organized in batch 03 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `csharp_semgrep_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added security-focused examples covering HTTP request handling patterns, with safe and unsafe variants.
  - Introduced examples for safe/unsafe JSON and SOAP deserialization configurations.
  - Provided guidance on XML reader defaults with secure alternatives.
  - Added a skeleton data contract resolver for future extensibility.

- Documentation
  - Included inline annotations highlighting insecure vs. secure patterns and recommended configurations to help developers avoid common pitfalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->