### PR TITLE
Add Csharp Files from csharp_semgrep_rules - Batch 04

### DIFF
--- a/javascript-serializer.cs
+++ b/javascript-serializer.cs
@@ -1,0 +1,45 @@
+using System.Web.Script.Serialization;
+
+namespace InsecureDeserialization
+{
+    public class InsecureJavascriptSerializerDeserialization
+    {
+        public void JavascriptSerializerDeserialization(string json)
+        {
+            try
+            {
+                //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                // ruleid: insecure-javascriptserializer-deserialization
+                var serializer = new JavaScriptSerializer(new SimpleTypeResolver());
+                serializer.DeserializeObject(json);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    internal class SimpleTypeResolver
+    {
+        public SimpleTypeResolver()
+        {
+        }
+    }
+
+    internal class JavaScriptSerializer
+    {
+        private SimpleTypeResolver simpleTypeResolver;
+
+        public JavaScriptSerializer(SimpleTypeResolver simpleTypeResolver)
+        {
+            this.simpleTypeResolver = simpleTypeResolver;
+        }
+
+        internal void DeserializeObject(string json)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+                //{/fact}

--- a/regioninfo-interop.cs
+++ b/regioninfo-interop.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using System.IO.Pipes;
+
+public class SamplesRegionInfo  {
+
+   public static void Main1()  {
+
+      // Creates a RegionInfo using the ISO 3166 two-letter code.
+      RegionInfo myRI1 = new RegionInfo( "US" );
+
+      // Creates a RegionInfo using a CultureInfo.LCID.
+      RegionInfo myRI2 = new RegionInfo( new CultureInfo("en-US",false).LCID );
+
+      using (AnonymousPipeServerStream pipeServer =
+                  new AnonymousPipeServerStream(PipeDirection.Out,
+                  HandleInheritability.Inheritable)){
+      using(StreamWriter sw = new StreamWriter(pipeServer)){
+         //{fact rule=correctness-regioninfo-interop@v1.0 defects=1}
+         //ruleid: correctness-regioninfo-interop
+         sw.WriteLine(myRI1);
+         //{/fact}
+
+         //{fact rule=correctness-regioninfo-interop@v1.0 defects=0}
+         //ok
+         sw.WriteLine(myRI2);
+      }}
+      //{/fact}
+   }
+}

--- a/rest-client.cs
+++ b/rest-client.cs
@@ -1,0 +1,185 @@
+using System;
+namespace ServerSideRequestForgery
+{
+
+    //error related object
+    public class Ssrf2
+    {
+        private object result;
+        #region Pattern 1
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void RestClientGet(string host)
+        {
+            try
+            {
+                RestClient client = new RestClient(host);
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+               // result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void RestClientGet1(string host)
+        {
+            try
+            {
+                RestClient client = new RestClient("constant");
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+               // result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+
+        #region Pattern 2
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void RestClientGetWithStringConcatenation(string host)
+        {
+            string uri = host + "constant";
+
+            try
+            {
+                RestClient client = new RestClient(uri);
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+               // result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void RestClientGetWithStringConcatenation1(string host)
+        {
+            string uri = "constant";
+
+            try
+            {
+                RestClient client = new RestClient(uri);
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+             //   result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=1}
+        // ruleid: ssrf
+        public void RestClientGetWithUri(string host)
+        {
+            Uri uri = new Uri(host + "constant");
+
+            try
+            {
+                RestClient client = new RestClient(uri);
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+            //    result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        //{/fact}
+
+        //{fact rule=server-side-request-forgery@v1.0 defects=0}
+        // ok: ssrf
+        public void RestClientGetWithUri1(string host)
+        {
+            Uri uri = new Uri("constant");
+
+            try
+            {
+                RestClient client = new RestClient(uri);
+
+                var request = new RestRequest("/");
+                var response = client.Get(request);
+
+               // result = response.Content;
+
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+        }
+
+        #endregion
+    }
+
+    internal class RestRequest
+    {
+        private string v;
+
+        public RestRequest(string v)
+        {
+            this.v = v;
+        }
+    }
+
+    internal class RestClient
+    {
+        private string host;
+        private Uri uri;
+
+        public RestClient(string host)
+        {
+            this.host = host;
+        }
+
+        public RestClient(Uri uri)
+        {
+            this.uri = uri;
+        }
+
+        internal object Get(RestRequest request)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+        //{/fact}

--- a/use_deprecated_cipher_algorithm.cs
+++ b/use_deprecated_cipher_algorithm.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Security.Cryptography;
+					
+public class Encryption
+{
+	public void CreateAes1() {
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_deprecated_cipher_algorithm
+		var key = Aes.Create();
+	}
+	//{/fact}
+	
+	public void CreateAes2() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_deprecated_cipher_algorithm
+		var key = Aes.Create("ImplementationName");
+	}
+	//{/fact}
+
+	public void CreateRijndael1() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_deprecated_cipher_algorithm
+		var key = Rijndael.Create();
+	}
+	//{/fact}
+	
+	public void CreateRijndael2() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=0}
+		//ok: use_deprecated_cipher_algorithm
+		var key = Rijndael.Create("ImplementationName");
+	}
+	//{/fact}
+
+	public void CreateDES1() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_deprecated_cipher_algorithm
+		var key = DES.Create(); // DevSkim: ignore DS106863
+	}
+	//{/fact}
+	
+	public void CreateDES2() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_deprecated_cipher_algorithm
+		var key = DES.Create("ImplementationName"); // DevSkim: ignore DS106863 until 2023-09-17
+	}
+	//{/fact}
+
+	public void CreateTripleDES1() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ok: use_deprecated_cipher_algorithm
+		var key = TripleDES.Create();
+	}
+	//{/fact}
+	
+	public void CreateTripleDES2() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ok: use_deprecated_cipher_algorithm
+		var key = TripleDES.Create("ImplementationName");
+	}
+	//{/fact}
+
+	public void CreateRC21() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_deprecated_cipher_algorithm
+		var key = RC2.Create();
+	}
+	//{/fact}
+	
+	public void CreateRC22() {
+
+		//{fact rule=insecure-cryptography@v1.0 defects=1}
+		//ruleid: use_deprecated_cipher_algorithm
+		var key = RC2.Create("ImplementationName");
+	}
+}		//{/fact}

--- a/xmlreadersettings-unsafe-parser-override.cs
+++ b/xmlreadersettings-unsafe-parser-override.cs
@@ -1,0 +1,154 @@
+using System.Xml;
+using System.IO;
+using System;
+class xmlreadersettings_unsafe_parser_override{
+
+
+public void ParseBad(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    //{fact rule=xml-external-entity@v1.0 defects=1}
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+//{/fact}
+
+public static void StaticParseBad(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+
+    //{fact rule=xml-external-entity@v1.0 defects=1}
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+//{/fact}
+
+public void ParseBad2(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    //{fact rule=xml-external-entity@v1.0 defects=1}
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(input,rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+//{/fact}
+
+public void ParseBad3(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    using(var reader = new StringReader(input)){
+
+        //{fact rule=xml-external-entity@v1.0 defects=1}
+        // ruleid:xmlreadersettings-unsafe-parser-override
+        XmlReader myReader = XmlReader.Create(reader,rs);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+}
+//{/fact}
+
+public void ParseGood(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Ignore;
+
+    //{fact rule=xml-external-entity@v1.0 defects=0}
+    // ok: xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+//{/fact}
+
+public void ParseGood2(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    // pre-override, not broken{/fact}
+    // pre-override, not broken
+    //{fact rule=xml-external-entity@v1.0 defects=0}
+    // ok: xmlreadersettings-unsafe-parser-override
+    using(var reader = new StringReader(input))//argument error
+    {
+        XmlReader myReader = XmlReader.Create(reader);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+    rs.DtdProcessing = DtdProcessing.Parse;
+    //{/fact}
+
+    // post-override, not providing reader settings, not broken{/fact}
+    // post-override, not providing reader settings, not broken
+    //{fact rule=xml-external-entity@v1.0 defects=0}
+    // ok: xmlreadersettings-unsafe-parser-override
+    using(var reader = new StringReader(input)){
+        XmlReader myReader = XmlReader.Create(reader);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+    //{/fact}
+}
+
+public void ParseGood3(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+
+    //{fact rule=xml-external-entity@v1.0 defects=0}
+    // ok: xmlreadersettings-unsafe-parser-override
+    var something = input;
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    var notInput = someSafeLoad();
+    //{/fact}
+
+    //{fact rule=xml-external-entity@v1.0 defects=0}
+    // ok: xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(notInput),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+
+string someSafeLoad()
+{
+    throw new NotImplementedException();
+}
+
+//{/fact}
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Csharp files from the `csharp_semgrep_rules` directory to the repository.

## 📁 Files Added
- Source Folder: `csharp_semgrep_rules`
- Batch: csharp-semgrep-rules-csharp-batch-04
- Language: Csharp
- Contains csharp files collected from the source directory

## 🔍 Changes
- Added csharp files from `csharp_semgrep_rules` maintaining original directory structure
- Files organized in batch 04 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `csharp_semgrep_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added sample demonstrating JSON deserialization with error handling.
  - Introduced a locale/region info sample that writes data through an inter-process pipe.
  - Included REST client examples covering different URL constructions and request flows.
  - Provided cryptography samples highlighting modern versus deprecated algorithms.
  - Added XML reading examples showcasing safe and unsafe parser configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->