### PR TITLE
Add Csharp Files from csharp_semgrep_rules - Batch 05

### DIFF
--- a/X509Certificate2-privkey.cs
+++ b/X509Certificate2-privkey.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+class CertSelect
+{
+    static void Main()
+    {
+        X509Store store = new X509Store("MY",StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+
+        X509Certificate2Collection collection = (X509Certificate2Collection)store.Certificates;
+        X509Certificate2Collection fcollection = (X509Certificate2Collection)collection.Find(X509FindType.FindByTimeValid,DateTime.Now,false);
+        X509Certificate2Collection scollection = X509Certificate2UI.SelectFromCollection(fcollection, "Test Certificate Select","Select a certificate from the following list to get information on that certificate",X509SelectionFlag.MultiSelection);
+
+        foreach (X509Certificate2 x509 in scollection)
+        {
+            try
+            {
+                //{fact rule=aws-kms-reencryption@v1.0 defects=1}
+                // ruleid: X509Certificate2-privkey
+                Console.WriteLine(x509.PrivateKey);
+            }
+            catch (CryptographicException)
+            {
+                Console.WriteLine("Information could not be written out for this certificate.");
+            }
+        }  //{/fact}
+        store.Close();
+
+        X509Certificate2 cert = new X509Certificate2();
+
+        //{fact rule=aws-kms-reencryption@v1.0 defects=1}
+        // ruleid: X509Certificate2-privkey
+        var privkey = cert.PrivateKey;
+    }
+}
+
+internal class X509SelectionFlag
+{
+    public static object MultiSelection { get; internal set; }
+}
+
+internal class X509Certificate2UI
+{
+    internal static X509Certificate2Collection SelectFromCollection(X509Certificate2Collection fcollection, string v1, string v2, object multiSelection)
+    {
+        throw new NotImplementedException();
+    }
+}
+//{/fact}

--- a/double-epsilon-equality.cs
+++ b/double-epsilon-equality.cs
@@ -1,0 +1,85 @@
+using System;
+
+public class Example
+{
+   static bool IsApproximatelyEqual(double value1, double value2, double epsilon)
+   {
+      // If they are equal anyway, just return True.
+      if (value1.Equals(value2))
+         return true;
+
+      // Handle NaN, Infinity.
+      if (Double.IsInfinity(value1) | Double.IsNaN(value1))
+         return value1.Equals(value2);
+      else if (Double.IsInfinity(value2) | Double.IsNaN(value2))
+         return value1.Equals(value2);
+
+      // Handle zero to avoid division by zero
+      double divisor = Math.Max(value1, value2);
+      if (divisor.Equals(0))
+         divisor = Math.Min(value1, value2);
+      //{fact rule=correctness-double-epsilon-equality@v1.0 defects=1}
+      //ruleid: correctness-double-epsilon-equality
+      return Math.Abs((value1 - value2) / divisor) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool lazyEqualLeftCompare(double v1, double v2){
+
+       //{fact rule=correctness-double-epsilon-equality@v1.0 defects=1}
+       //ruleid: correctness-double-epsilon-equality
+       return Math.Abs(v1 - v2) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool lazyEqualRightCompare(double v1, double v2){
+
+       //{fact rule=correctness-double-epsilon-equality@v1.0 defects=1}
+       //ruleid: correctness-double-epsilon-equality
+       return  Double.Epsilon <= Math.Abs(v1 - v2);
+   }
+   //{/fact}
+
+   static bool uselessZeroEqual(){
+       double v1 = 0;
+       double v2 = 0;
+        //{fact rule=correctness-double-epsilon-equality@v1.0 defects=0}
+       //ok
+       return Math.Abs(v1 - v2) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool isZero(double arg){
+       double zero = 0;
+        //{fact rule=correctness-double-epsilon-equality@v1.0 defects=0}
+       //ok
+       return Math.Abs(arg - zero) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool isZero2(double arg){
+       double zero = 0;
+       //{fact rule=correctness-double-epsilon-equality@v1.0 defects=0}
+       //ok
+       return Math.Abs(zero - arg) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool isZero3(double arg){
+       double zero;
+       zero = 0;
+       //{fact rule=correctness-double-epsilon-equality@v1.0 defects=0}
+       //ok
+       return Math.Abs(zero - arg) <= Double.Epsilon;
+   }
+   //{/fact}
+
+   static bool isZero4(double arg){
+       double zero;
+       zero = 0;
+       //{fact rule=correctness-double-epsilon-equality@v1.0 defects=0}
+       //ok
+       return Math.Abs(arg - zero) <= Double.Epsilon;
+   }
+   //{/fact}
+}

--- a/fast-json.cs
+++ b/fast-json.cs
@@ -1,0 +1,33 @@
+namespace InsecureDeserialization
+{
+    public class InsecureFastJSONDeserialization
+    {
+        public void FastJSONDeserialization(string json)
+        {
+            try
+            {
+                //{fact rule=untrusted-deserialization@v1.0 defects=1}
+                // ruleid: insecure-fastjson-deserialization
+                var obj = JSON.ToObject(json, new JSONParameters { BadListTypeChecking = false });
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    internal class JSON
+    {
+        internal static object ToObject(string json, JSONParameters jSONParameters)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class JSONParameters
+    {
+        public bool BadListTypeChecking { get; set; }
+    }
+}
+                //{/fact}

--- a/regular-expression-dos.cs
+++ b/regular-expression-dos.cs
@@ -1,0 +1,69 @@
+using System.Text.RegularExpressions;
+
+namespace RegularExpressionsDos
+{
+    public class RegularExpressionsDos
+    {
+        //{fact rule=regular-expression-dos@v1.0 defects=1}
+        // ruleid: regular-expression-dos
+        public void ValidateRegex(string search)
+        {
+            Regex rgx = new Regex("^A(B|C+)+D");
+            rgx.Match(search);
+
+        }
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos@v1.0 defects=1}
+        // ruleid: regular-expression-dos
+        public void ValidateRegex2(string search)
+        {
+            Regex rgx = new Regex("^A(B|C+)+D", new RegexOptions { });
+            rgx.Match(search);
+
+        }
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos@v1.0 defects=0}
+        // ok: regular-expression-dos
+        public void ValidateRegex3(string search)
+        {
+            Regex rgx = new Regex("^A(B|C+)+D", new RegexOptions { }, TimeSpan.FromSeconds(4));
+            rgx.Match(search);
+
+        }
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos@v1.0 defects=1}
+        // ruleid: regular-expression-dos
+        public void Validate4(string search)
+        {
+            var pattern = @"^A(B|C+)+D";
+            var result = Regex.Match(search, pattern);
+        }
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos@v1.0 defects=1}
+        // ruleid: regular-expression-dos
+        public void Validate5(string search)
+        {
+            var pattern = @"^A(B|C+)+D";
+            var result = Regex.Match(search, pattern, new RegexOptions { });
+        }
+
+        //{/fact}
+
+        //{fact rule=regular-expression-dos@v1.0 defects=0}
+        // ok: regular-expression-dos
+        public void Validate6(string search)
+        {
+            var pattern = @"^A(B|C+)+D";
+            var result = Regex.Match(search, pattern, new RegexOptions { }, TimeSpan.FromSeconds(4));
+        }
+    }
+}
+        //{/fact}

--- a/sslcertificatetrust-handshake-no-trust.cs
+++ b/sslcertificatetrust-handshake-no-trust.cs
@@ -1,0 +1,58 @@
+using System.Net.Security;
+
+public class Foo1{
+    private bool sendTrustInHandshake;
+
+    private void SomeFunction(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+        //{fact rule=sensitive-information-leak@v1.0 defects=1}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,true);
+    }
+     //{/fact}
+
+    private void SomeFunction2(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=1}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,sendTrustInHandshake=true);
+    }
+    //{/fact}
+
+    private void SomeFunction3(string arg1, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ok: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection);
+    }
+     //{/fact}
+
+    private void SomeFunction4(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=1}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,true);
+    }
+     //{/fact}
+
+    private void SomeFunction5(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=1}
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,sendTrustInHandshake=true);
+    }
+     //{/fact}
+
+    private void SomeFunction6(string arg1, System.Security.Cryptography.X509Certificates.X509Store certCollection)
+    {
+
+        //{fact rule=sensitive-information-leak@v1.0 defects=0}
+        //ok: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection);
+    }
+}
+        //{/fact}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Csharp files from the `csharp_semgrep_rules` directory to the repository.

## 📁 Files Added
- Source Folder: `csharp_semgrep_rules`
- Batch: csharp-semgrep-rules-csharp-batch-05
- Language: Csharp
- Contains csharp files collected from the source directory

## 🔍 Changes
- Added csharp files from `csharp_semgrep_rules` maintaining original directory structure
- Files organized in batch 05 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `csharp_semgrep_rules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added certificate selection and viewing utilities, including UI-based selection from the user store.
  - Introduced numeric comparison helpers for double values with epsilon-based equality checks.
  - Added regex validation methods demonstrating multiple matching options and usage patterns.
  - Provided a JSON deserialization helper with configurable parameters.
  - Added helpers to create SSL certificate trust from collections or stores with optional handshake trust configuration.
- Chores
  - Added scaffolding and placeholders for future UI and parameter configuration components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->